### PR TITLE
Update CI Ruby and bump nokogiri

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,14 @@ jobs:
         rm -rf _site
         sudo chmod -R 777 .
 
-    - name: Jekyll build
-      uses: docker://jekyll/jekyll:latest
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
-        args: bash -c "gem install bundler && jekyll build -V"
+        ruby-version: '3.2'
+        bundler-cache: true
+
+    - name: Jekyll build
+      run: bundle exec jekyll build -V
       env:
         JEKYLL_ENV: 'production'
         

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,4 @@ end
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
 gem "faraday", "< 3.0"
-gem "nokogiri", "< 1.19"
+gem "nokogiri", ">= 1.19.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,14 +79,14 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.18.4)
+    nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octicons (9.5.0)
@@ -139,7 +139,7 @@ DEPENDENCIES
   jekyll-twitter-plugin
   kramdown-math-katex
   minima
-  nokogiri (< 1.19)
+  nokogiri (>= 1.19.1)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)


### PR DESCRIPTION
- Update CI to Ruby 3.2
- Bump nokogiri to 1.19.1 to address Dependabot alerts
